### PR TITLE
Fix Portuguese accent in listas comment

### DIFF
--- a/utils/listas.py
+++ b/utils/listas.py
@@ -3,7 +3,7 @@
 centraliza_udi = -18.933551379794125, -48.27580804079593
 
 
-# Dicicionarios dos terminais
+# Dicionários dos terminais
 
 Dic_Terminais = {
                 "Central": {


### PR DESCRIPTION
## Summary
- fix a typo in `listas.py`

## Testing
- `python -m py_compile utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6840dd8c4ec48329ba53ddaaefeb8a09